### PR TITLE
more precise whitelist

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,11 @@
-{ nixpkgs ? import ./nixpkgs.nix { config = { allowUnfree = true; }; } }:
 let
+  nixpkgs = import ./nixpkgs.nix {
+    config = {
+      allowUnfreePredicate = pkg: builtins.elem (pkg.name) [
+        "mkl-2019.0.117"
+      ];
+    };
+  };
   callPackage = nixpkgs.lib.callPackageWith (nixpkgs // pkgs);
   pkgs = {
     arrayfire = callPackage ./arrayfire.nix { };


### PR DESCRIPTION
This build is actually redistributable under the [ISSL](https://software.intel.com/en-us/license/intel-simplified-software-license). This pull request makes it clear that this repo only uses redistributable software, paving way for redistribution. In newer versions of nixpkgs, can be improved to:

```
      config = with pkgs.stdenv; {
        whitelistedLicenses = with lib.licenses; [
          issl
         ];
      };

```